### PR TITLE
Add missing ERROR_NO_DATA handling to NamedPipe

### DIFF
--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -223,6 +223,7 @@ impl NamedPipe {
             Ok(_) => Ok(true),
             Err(ref e) if e.raw_os_error() == Some(ERROR_PIPE_CONNECTED as i32) => Ok(true),
             Err(ref e) if e.raw_os_error() == Some(ERROR_IO_PENDING as i32) => Ok(false),
+            Err(ref e) if e.raw_os_error() == Some(ERROR_NO_DATA as i32) => Ok(true),
             Err(e) => Err(e),
         }
     }


### PR DESCRIPTION
Hey @yoshuawuyts, found an interesting problem.

I needed to check that the ACLs on my named pipe were set correctly, so I used [accesschk](https://docs.microsoft.com/en-us/sysinternals/downloads/accesschk). Surprisingly, everything crashed. The error I was given: Error 232, "The pipe is being closed."

I search, find this is the define `ERROR_NO_DATA`. [The documentation for ConnectNamedPipe](https://docs.microsoft.com/en-us/windows/win32/api/namedpipeapi/nf-namedpipeapi-connectnamedpipe) says:

> Otherwise, ConnectNamedPipe returns zero, and GetLastError returns ERROR_NO_DATA if the previous client has closed its handle or ERROR_PIPE_CONNECTED if it has not closed its handle.

With this patch, `accesschk` works, and without it, it doesn't.  If you change the return value to `Ok(false)` it also will not work correctly.