### PR TITLE
Bump socket2 dependency to a version that does not assume memory layout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-target = "x86_64-pc-windows-msvc"
 targets = ["aarch64-pc-windows-msvc", "i686-pc-windows-msvc", "x86_64-pc-windows-msvc"]
 
 [dependencies]
-socket2 = "0.3"
+socket2 = "0.3.16"
 
 [dependencies.winapi]
 version = "0.3.3"


### PR DESCRIPTION
Bumps the minimum required `socket2` version to a version that does not invalidly assume the memory layout of `std::net::SocketAddr`. This was fixed in `socket2` in https://github.com/rust-lang/socket2-rs/pull/120.

It would help unblock https://github.com/rust-lang/rust/pull/78802 if we can make the ecosystem migrate away from the older versions faster.