### PR TITLE
Don't assume memory layout of std::net::SocketAddr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-target = "x86_64-pc-windows-msvc"
 targets = ["aarch64-pc-windows-msvc", "i686-pc-windows-msvc", "x86_64-pc-windows-msvc"]
 
 [dependencies]
-socket2 = "0.3"
+socket2 = "0.3.16"
 
 [dependencies.winapi]
 version = "0.3.3"

--- a/src/net.rs
+++ b/src/net.rs
@@ -1020,7 +1020,9 @@ impl WsaExtension {
 #[cfg(test)]
 mod tests {
     use std::io::prelude::*;
-    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV6, TcpListener, TcpStream, UdpSocket};
+    use std::net::{
+        IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV6, TcpListener, TcpStream, UdpSocket,
+    };
     use std::slice;
     use std::thread;
 
@@ -1296,8 +1298,12 @@ mod tests {
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(3, 4, 5, 6)), 0xabcd);
         let (raw_addr, addr_len) = super::socket_addr_to_ptrs(&addr);
         assert_eq!(addr_len, 16);
-        let addr_bytes = unsafe { slice::from_raw_parts(raw_addr as *const u8, addr_len as usize) };
-        assert_eq!(addr_bytes, &[2, 0, 0xab, 0xcd, 3, 4, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0]);
+        let addr_bytes =
+            unsafe { slice::from_raw_parts(raw_addr.as_ptr() as *const u8, addr_len as usize) };
+        assert_eq!(
+            addr_bytes,
+            &[2, 0, 0xab, 0xcd, 3, 4, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0]
+        );
     }
 
     #[test]
@@ -1306,19 +1312,27 @@ mod tests {
         let flowinfo = 0x12345678;
         let scope_id = 0x87654321;
         let addr = SocketAddr::V6(SocketAddrV6::new(
-            Ipv6Addr::new(0x0102, 0x0304, 0x0506, 0x0708, 0x090a, 0x0b0c, 0x0d0e, 0x0f10),
+            Ipv6Addr::new(
+                0x0102, 0x0304, 0x0506, 0x0708, 0x090a, 0x0b0c, 0x0d0e, 0x0f10,
+            ),
             port,
             flowinfo,
-            scope_id
+            scope_id,
         ));
         let (raw_addr, addr_len) = super::socket_addr_to_ptrs(&addr);
         assert_eq!(addr_len, 28);
-        let addr_bytes = unsafe { slice::from_raw_parts(raw_addr as *const u8, addr_len as usize) };
-        assert_eq!(addr_bytes, &[
-            23, 0, // AF_INET6
-            0xab, 0xcd, // Port
-            0x78, 0x56, 0x34, 0x12, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, // IP
-            0x21, 0x43, 0x65, 0x87, // scope_id
-        ]);
+        let addr_bytes =
+            unsafe { slice::from_raw_parts(raw_addr.as_ptr() as *const u8, addr_len as usize) };
+        assert_eq!(
+            addr_bytes,
+            &[
+                23, 0, // AF_INET6
+                0xab, 0xcd, // Port
+                0x78, 0x56, 0x34, 0x12, // flowinfo
+                0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+                0x0f, 0x10, // IP
+                0x21, 0x43, 0x65, 0x87, // scope_id
+            ]
+        );
     }
 }


### PR DESCRIPTION
Fixes #38. Makes #37 obsolete...

Stops just converting from `std::net::SocketAddr` -> `SOCKADDR` by casting the pointer. The memory layout of the types in the standard library can't be assumed to be stable.

The `socket2` minimum version bump is because that crate also made this assumption. But `0.3.16` has been fixed and no longer does that.

Helps unblock https://github.com/rust-lang/rust/pull/78802