### PR TITLE
Remove old cruft

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ abstractions.
 default-target = "x86_64-pc-windows-msvc"
 targets = ["aarch64-pc-windows-msvc", "i686-pc-windows-msvc", "x86_64-pc-windows-msvc"]
 
-[dependencies]
 
 [dependencies.winapi]
 version = "0.3.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,11 +5,6 @@
 #![allow(bad_style)]
 #![doc(html_root_url = "https://docs.rs/miow/0.3/x86_64-pc-windows-msvc/")]
 
-extern crate winapi;
-
-#[cfg(test)]
-extern crate rand;
-
 use std::cmp;
 use std::io;
 use std::time::Duration;


### PR DESCRIPTION
Remove the now empty `[dependencies]` section. Also remove `extern crate` declarations that are not needed in Rust 2018.