### PR TITLE
Mark CompletionStatus as repr(transparent) to guarantee layout

### DIFF
--- a/src/iocp.rs
+++ b/src/iocp.rs
@@ -27,6 +27,7 @@ pub struct CompletionPort {
 /// provided to a completion port, or they are read out of a completion port.
 /// The fields of each status are read through its accessor methods.
 #[derive(Clone, Copy)]
+#[repr(transparent)]
 pub struct CompletionStatus(OVERLAPPED_ENTRY);
 
 impl fmt::Debug for CompletionStatus {
@@ -227,6 +228,9 @@ impl CompletionStatus {
     /// This method will wrap the `OVERLAPPED_ENTRY` in a `CompletionStatus`,
     /// returning the wrapped structure.
     pub fn from_entry(entry: &OVERLAPPED_ENTRY) -> &CompletionStatus {
+        // Safety: CompletionStatus is repr(transparent) w/ OVERLAPPED_ENTRY, so
+        // a reference to one is guaranteed to be layout compatible with the
+        // reference to another.
         unsafe { &*(entry as *const _ as *const _) }
     }
 


### PR DESCRIPTION
This is required to guarantee that the compiler won't fiddle with the layout of the struct so that a reference to one is compatible with another.

In practice I only think it's ever mattered for floats, but this asserts that it won't break in the future.