### PR TITLE
Migrate from `winapi` to `windows-sys`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,22 +18,18 @@ abstractions.
 default-target = "x86_64-pc-windows-msvc"
 targets = ["aarch64-pc-windows-msvc", "i686-pc-windows-msvc", "x86_64-pc-windows-msvc"]
 
-
-[dependencies.winapi]
-version = "0.3.3"
+[dependencies.windows-sys]
+path = "/git/windows-rs/crates/deps/sys"
 features = [
-  "std",
-  "fileapi",
-  "handleapi",
-  "ioapiset",
-  "minwindef",
-  "namedpipeapi",
-  "ntdef",
-  "synchapi",
-  "winerror",
-  "winsock2",
-  "ws2def",
-  "ws2ipdef",
+  "Win32_Foundation",
+  "Win32_Networking_WinSock",
+  "Win32_NetworkManagement_IpHelper",
+  "Win32_Security",
+  "Win32_Storage_FileSystem",
+  "Win32_System_IO",
+  "Win32_System_Pipes",
+  "Win32_System_Threading",
+  "Win32_System_WindowsProgramming",
 ]
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-target = "x86_64-pc-windows-msvc"
 targets = ["aarch64-pc-windows-msvc", "i686-pc-windows-msvc", "x86_64-pc-windows-msvc"]
 
 [dependencies.windows-sys]
-path = "/git/windows-rs/crates/deps/sys"
+version = "0.28.0"
 features = [
   "Win32_Foundation",
   "Win32_Networking_WinSock",

--- a/src/iocp.rs
+++ b/src/iocp.rs
@@ -1,5 +1,6 @@
 //! Bindings to IOCP, I/O Completion Ports
 
+use crate::*;
 use std::cmp;
 use std::fmt;
 use std::io;
@@ -9,11 +10,7 @@ use std::time::Duration;
 
 use crate::handle::Handle;
 use crate::Overlapped;
-use winapi::shared::basetsd::*;
-use winapi::shared::ntdef::*;
-use winapi::um::handleapi::*;
-use winapi::um::ioapiset::*;
-use winapi::um::minwinbase::*;
+use windows_sys::Win32::System::IO::*;
 
 /// A handle to an Windows I/O Completion Port.
 #[derive(Debug)]
@@ -46,8 +43,8 @@ impl CompletionPort {
     /// allowed for threads associated with this port. Consult the Windows
     /// documentation for more information about this value.
     pub fn new(threads: u32) -> io::Result<CompletionPort> {
-        let ret = unsafe { CreateIoCompletionPort(INVALID_HANDLE_VALUE, 0 as *mut _, 0, threads) };
-        if ret.is_null() {
+        let ret = unsafe { CreateIoCompletionPort(INVALID_HANDLE_VALUE, 0, 0, threads) };
+        if ret == 0 {
             Err(io::Error::last_os_error())
         } else {
             Ok(CompletionPort {
@@ -66,7 +63,7 @@ impl CompletionPort {
     /// trait can be provided to this function, such as `std::fs::File` and
     /// friends.
     pub fn add_handle<T: AsRawHandle + ?Sized>(&self, token: usize, t: &T) -> io::Result<()> {
-        self._add(token, t.as_raw_handle())
+        self._add(token, t.as_raw_handle() as _)
     }
 
     /// Associates a new `SOCKET` to this I/O completion port.
@@ -83,10 +80,9 @@ impl CompletionPort {
     }
 
     fn _add(&self, token: usize, handle: HANDLE) -> io::Result<()> {
-        assert_eq!(mem::size_of_val(&token), mem::size_of::<ULONG_PTR>());
-        let ret =
-            unsafe { CreateIoCompletionPort(handle, self.handle.raw(), token as ULONG_PTR, 0) };
-        if ret.is_null() {
+        assert_eq!(mem::size_of_val(&token), mem::size_of::<usize>());
+        let ret = unsafe { CreateIoCompletionPort(handle, self.handle.raw(), token as usize, 0) };
+        if ret == 0 {
             Err(io::Error::last_os_error())
         } else {
             debug_assert_eq!(ret, self.handle.raw());
@@ -151,7 +147,7 @@ impl CompletionPort {
         );
         let mut removed = 0;
         let timeout = crate::dur2ms(timeout);
-        let len = cmp::min(list.len(), <ULONG>::max_value() as usize) as ULONG;
+        let len = cmp::min(list.len(), <u32>::max_value() as usize) as u32;
         let ret = unsafe {
             GetQueuedCompletionStatusEx(
                 self.handle.raw(),
@@ -187,22 +183,22 @@ impl CompletionPort {
 }
 
 impl AsRawHandle for CompletionPort {
-    fn as_raw_handle(&self) -> HANDLE {
-        self.handle.raw()
+    fn as_raw_handle(&self) -> *mut std::ffi::c_void {
+        self.handle.raw() as _
     }
 }
 
 impl FromRawHandle for CompletionPort {
-    unsafe fn from_raw_handle(handle: HANDLE) -> CompletionPort {
+    unsafe fn from_raw_handle(handle: *mut std::ffi::c_void) -> CompletionPort {
         CompletionPort {
-            handle: Handle::new(handle),
+            handle: Handle::new(handle as _),
         }
     }
 }
 
 impl IntoRawHandle for CompletionPort {
-    fn into_raw_handle(self) -> HANDLE {
-        self.handle.into_raw()
+    fn into_raw_handle(self) -> *mut std::ffi::c_void {
+        self.handle.into_raw() as _
     }
 }
 
@@ -213,10 +209,10 @@ impl CompletionStatus {
     /// the `post` method. The parameters are opaquely passed through and not
     /// interpreted by the system at all.
     pub fn new(bytes: u32, token: usize, overlapped: *mut Overlapped) -> CompletionStatus {
-        assert_eq!(mem::size_of_val(&token), mem::size_of::<ULONG_PTR>());
+        assert_eq!(mem::size_of_val(&token), mem::size_of::<usize>());
         CompletionStatus(OVERLAPPED_ENTRY {
             dwNumberOfBytesTransferred: bytes,
-            lpCompletionKey: token as ULONG_PTR,
+            lpCompletionKey: token as usize,
             lpOverlapped: overlapped as *mut _,
             Internal: 0,
         })
@@ -271,13 +267,10 @@ impl CompletionStatus {
 
 #[cfg(test)]
 mod tests {
+    use crate::iocp::{CompletionPort, CompletionStatus};
     use std::mem;
     use std::time::Duration;
-
-    use winapi::shared::basetsd::*;
-    use winapi::shared::winerror::*;
-
-    use crate::iocp::{CompletionPort, CompletionStatus};
+    use windows_sys::Win32::Foundation::*;
 
     #[test]
     fn is_send_sync() {
@@ -287,14 +280,14 @@ mod tests {
 
     #[test]
     fn token_right_size() {
-        assert_eq!(mem::size_of::<usize>(), mem::size_of::<ULONG_PTR>());
+        assert_eq!(mem::size_of::<usize>(), mem::size_of::<usize>());
     }
 
     #[test]
     fn timeout() {
         let c = CompletionPort::new(1).unwrap();
         let err = c.get(Some(Duration::from_millis(1))).unwrap_err();
-        assert_eq!(err.raw_os_error(), Some(WAIT_TIMEOUT as i32));
+        assert_eq!(err.raw_os_error(), Some(WAIT_TIMEOUT as _));
     }
 
     #[test]

--- a/src/iocp.rs
+++ b/src/iocp.rs
@@ -43,7 +43,7 @@ impl CompletionPort {
     /// allowed for threads associated with this port. Consult the Windows
     /// documentation for more information about this value.
     pub fn new(threads: u32) -> io::Result<CompletionPort> {
-        let ret = unsafe { CreateIoCompletionPort(INVALID_HANDLE_VALUE, std::ptr::null_mut(), 0, threads) };
+        let ret = unsafe { CreateIoCompletionPort(INVALID_HANDLE_VALUE, 0 as *mut _, 0, threads) };
         if ret.is_null() {
             Err(io::Error::last_os_error())
         } else {
@@ -63,7 +63,7 @@ impl CompletionPort {
     /// trait can be provided to this function, such as `std::fs::File` and
     /// friends.
     pub fn add_handle<T: AsRawHandle + ?Sized>(&self, token: usize, t: &T) -> io::Result<()> {
-        self._add(token, t.as_raw_handle() as _)
+        self._add(token, t.as_raw_handle())
     }
 
     /// Associates a new `SOCKET` to this I/O completion port.
@@ -183,22 +183,22 @@ impl CompletionPort {
 }
 
 impl AsRawHandle for CompletionPort {
-    fn as_raw_handle(&self) -> *mut std::ffi::c_void {
-        self.handle.raw() as _
+    fn as_raw_handle(&self) -> HANDLE {
+        self.handle.raw()
     }
 }
 
 impl FromRawHandle for CompletionPort {
-    unsafe fn from_raw_handle(handle: *mut std::ffi::c_void) -> CompletionPort {
+    unsafe fn from_raw_handle(handle: HANDLE) -> CompletionPort {
         CompletionPort {
-            handle: Handle::new(handle as _),
+            handle: Handle::new(handle),
         }
     }
 }
 
 impl IntoRawHandle for CompletionPort {
-    fn into_raw_handle(self) -> *mut std::ffi::c_void {
-        self.handle.into_raw() as _
+    fn into_raw_handle(self) -> HANDLE {
+        self.handle.into_raw()
     }
 }
 

--- a/src/iocp.rs
+++ b/src/iocp.rs
@@ -287,7 +287,7 @@ mod tests {
     fn timeout() {
         let c = CompletionPort::new(1).unwrap();
         let err = c.get(Some(Duration::from_millis(1))).unwrap_err();
-        assert_eq!(err.raw_os_error(), Some(WAIT_TIMEOUT as _));
+        assert_eq!(err.raw_os_error(), Some(WAIT_TIMEOUT as i32));
     }
 
     #[test]

--- a/src/iocp.rs
+++ b/src/iocp.rs
@@ -43,8 +43,8 @@ impl CompletionPort {
     /// allowed for threads associated with this port. Consult the Windows
     /// documentation for more information about this value.
     pub fn new(threads: u32) -> io::Result<CompletionPort> {
-        let ret = unsafe { CreateIoCompletionPort(INVALID_HANDLE_VALUE, 0, 0, threads) };
-        if ret == 0 {
+        let ret = unsafe { CreateIoCompletionPort(INVALID_HANDLE_VALUE, std::ptr::null_mut(), 0, threads) };
+        if ret.is_null() {
             Err(io::Error::last_os_error())
         } else {
             Ok(CompletionPort {
@@ -82,7 +82,7 @@ impl CompletionPort {
     fn _add(&self, token: usize, handle: HANDLE) -> io::Result<()> {
         assert_eq!(mem::size_of_val(&token), mem::size_of::<usize>());
         let ret = unsafe { CreateIoCompletionPort(handle, self.handle.raw(), token as usize, 0) };
-        if ret == 0 {
+        if ret.is_null() {
             Err(io::Error::last_os_error())
         } else {
             debug_assert_eq!(ret, self.handle.raw());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,8 @@ use std::cmp;
 use std::io;
 use std::time::Duration;
 
-use winapi::shared::minwindef::*;
-use winapi::um::winbase::*;
+use windows_sys::Win32::Foundation::*;
+use windows_sys::Win32::System::WindowsProgramming::*;
 
 #[cfg(test)]
 macro_rules! t {
@@ -30,6 +30,8 @@ pub mod net;
 pub mod pipe;
 
 pub use crate::overlapped::Overlapped;
+pub(crate) const TRUE: BOOL = 1;
+pub(crate) const FALSE: BOOL = 0;
 
 fn cvt(i: BOOL) -> io::Result<BOOL> {
     if i == 0 {

--- a/src/net.rs
+++ b/src/net.rs
@@ -3,6 +3,7 @@
 //! This module contains a number of extension traits for the types in
 //! `std::net` for Windows-specific functionality.
 
+use crate::*;
 use std::cmp;
 use std::io;
 use std::mem;
@@ -11,18 +12,10 @@ use std::net::{SocketAddr, TcpListener, TcpStream, UdpSocket};
 use std::os::windows::prelude::*;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use winapi::ctypes::*;
-use winapi::shared::guiddef::*;
-use winapi::shared::in6addr::{in6_addr_u, IN6_ADDR};
-use winapi::shared::inaddr::{in_addr_S_un, IN_ADDR};
-use winapi::shared::minwindef::*;
-use winapi::shared::minwindef::{FALSE, TRUE};
-use winapi::shared::ntdef::*;
-use winapi::shared::ws2def::SOL_SOCKET;
-use winapi::shared::ws2def::*;
-use winapi::shared::ws2ipdef::*;
-use winapi::um::minwinbase::*;
-use winapi::um::winsock2::*;
+use windows_sys::core::*;
+use windows_sys::Win32::NetworkManagement::IpHelper::*;
+use windows_sys::Win32::Networking::WinSock::*;
+use windows_sys::Win32::System::IO::*;
 
 /// A type to represent a buffer in which a socket address will be stored.
 ///
@@ -32,7 +25,7 @@ use winapi::um::winsock2::*;
 #[derive(Clone, Copy)]
 pub struct SocketAddrBuf {
     buf: SOCKADDR_STORAGE,
-    len: c_int,
+    len: i32,
 }
 
 /// A type to represent a buffer in which an accepted socket's address will be
@@ -54,10 +47,10 @@ pub struct AcceptAddrsBuf {
 
 /// The parsed return value of `AcceptAddrsBuf`.
 pub struct AcceptAddrs<'a> {
-    local: LPSOCKADDR,
-    local_len: c_int,
-    remote: LPSOCKADDR,
-    remote_len: c_int,
+    local: *mut SOCKADDR,
+    local_len: i32,
+    remote: *mut SOCKADDR,
+    remote_len: i32,
     _data: &'a AcceptAddrsBuf,
 }
 
@@ -450,7 +443,7 @@ fn last_err() -> io::Result<Option<usize>> {
     }
 }
 
-fn cvt(i: c_int, size: DWORD) -> io::Result<Option<usize>> {
+fn cvt(i: i32, size: u32) -> io::Result<Option<usize>> {
     if i == SOCKET_ERROR {
         last_err()
     } else {
@@ -465,7 +458,7 @@ fn cvt(i: c_int, size: DWORD) -> io::Result<Option<usize>> {
 #[repr(C)]
 pub(crate) union SocketAddrCRepr {
     v4: SOCKADDR_IN,
-    v6: SOCKADDR_IN6_LH,
+    v6: SOCKADDR_IN6,
 }
 
 impl SocketAddrCRepr {
@@ -474,70 +467,65 @@ impl SocketAddrCRepr {
     }
 }
 
-fn socket_addr_to_ptrs(addr: &SocketAddr) -> (SocketAddrCRepr, c_int) {
+fn socket_addr_to_ptrs(addr: &SocketAddr) -> (SocketAddrCRepr, i32) {
     match *addr {
         SocketAddr::V4(ref a) => {
-            let sin_addr = unsafe {
-                let mut s_un = mem::zeroed::<in_addr_S_un>();
-                *s_un.S_addr_mut() = u32::from_ne_bytes(a.ip().octets());
-                IN_ADDR { S_un: s_un }
+            let sin_addr = IN_ADDR {
+                S_un: IN_ADDR_0 {
+                    S_addr: u32::from_ne_bytes(a.ip().octets()),
+                },
             };
 
             let sockaddr_in = SOCKADDR_IN {
-                sin_family: AF_INET as ADDRESS_FAMILY,
+                sin_family: AF_INET as _,
                 sin_port: a.port().to_be(),
                 sin_addr,
                 sin_zero: [0; 8],
             };
 
             let sockaddr = SocketAddrCRepr { v4: sockaddr_in };
-            (sockaddr, mem::size_of::<SOCKADDR_IN>() as c_int)
+            (sockaddr, mem::size_of::<SOCKADDR_IN>() as i32)
         }
         SocketAddr::V6(ref a) => {
-            let sin6_addr = unsafe {
-                let mut u = mem::zeroed::<in6_addr_u>();
-                *u.Byte_mut() = a.ip().octets();
-                IN6_ADDR { u }
-            };
-            let u = unsafe {
-                let mut u = mem::zeroed::<SOCKADDR_IN6_LH_u>();
-                *u.sin6_scope_id_mut() = a.scope_id();
-                u
-            };
-
-            let sockaddr_in6 = SOCKADDR_IN6_LH {
-                sin6_family: AF_INET6 as ADDRESS_FAMILY,
+            let sockaddr_in6 = SOCKADDR_IN6 {
+                sin6_family: AF_INET6 as _,
                 sin6_port: a.port().to_be(),
-                sin6_addr,
+                sin6_addr: IN6_ADDR {
+                    u: IN6_ADDR_0 {
+                        Byte: a.ip().octets(),
+                    },
+                },
                 sin6_flowinfo: a.flowinfo(),
-                u,
+                Anonymous: SOCKADDR_IN6_0 {
+                    sin6_scope_id: a.scope_id(),
+                },
             };
 
             let sockaddr = SocketAddrCRepr { v6: sockaddr_in6 };
-            (sockaddr, mem::size_of::<SOCKADDR_IN6_LH>() as c_int)
+            (sockaddr, mem::size_of::<SOCKADDR_IN6>() as i32)
         }
     }
 }
 
-unsafe fn ptrs_to_socket_addr(ptr: *const SOCKADDR, len: c_int) -> Option<SocketAddr> {
-    if (len as usize) < mem::size_of::<c_int>() {
+unsafe fn ptrs_to_socket_addr(ptr: *const SOCKADDR, len: i32) -> Option<SocketAddr> {
+    if (len as usize) < mem::size_of::<i32>() {
         return None;
     }
-    match (*ptr).sa_family as i32 {
+    match (*ptr).sa_family as _ {
         AF_INET if len as usize >= mem::size_of::<SOCKADDR_IN>() => {
             let b = &*(ptr as *const SOCKADDR_IN);
-            let ip = ntoh(*b.sin_addr.S_un.S_addr());
+            let ip = ntoh(b.sin_addr.S_un.S_addr);
             let ip = Ipv4Addr::new(
                 (ip >> 24) as u8,
                 (ip >> 16) as u8,
                 (ip >> 8) as u8,
-                (ip >> 0) as u8,
+                ip as u8,
             );
             Some(SocketAddr::V4(SocketAddrV4::new(ip, ntoh(b.sin_port))))
         }
-        AF_INET6 if len as usize >= mem::size_of::<SOCKADDR_IN6_LH>() => {
-            let b = &*(ptr as *const SOCKADDR_IN6_LH);
-            let arr = b.sin6_addr.u.Byte();
+        AF_INET6 if len as usize >= mem::size_of::<SOCKADDR_IN6>() => {
+            let b = &*(ptr as *const SOCKADDR_IN6);
+            let arr = &b.sin6_addr.u.Byte;
             let ip = Ipv6Addr::new(
                 ((arr[0] as u16) << 8) | (arr[1] as u16),
                 ((arr[2] as u16) << 8) | (arr[3] as u16),
@@ -552,7 +540,7 @@ unsafe fn ptrs_to_socket_addr(ptr: *const SOCKADDR, len: c_int) -> Option<Socket
                 ip,
                 ntoh(b.sin6_port),
                 ntoh(b.sin6_flowinfo),
-                ntoh(*b.u.sin6_scope_id()),
+                ntoh(b.Anonymous.sin6_scope_id),
             );
             Some(SocketAddr::V6(addr))
         }
@@ -562,7 +550,7 @@ unsafe fn ptrs_to_socket_addr(ptr: *const SOCKADDR, len: c_int) -> Option<Socket
 
 unsafe fn slice2buf(slice: &[u8]) -> WSABUF {
     WSABUF {
-        len: cmp::min(slice.len(), <u_long>::max_value() as usize) as u_long,
+        len: cmp::min(slice.len(), <u32>::max_value() as usize) as u32,
         buf: slice.as_ptr() as *mut _,
     }
 }
@@ -586,7 +574,7 @@ impl TcpStreamExt for TcpStream {
     ) -> io::Result<Option<usize>> {
         let mut buf = slice2buf(buf);
         let mut flags = 0;
-        let mut bytes_read: DWORD = 0;
+        let mut bytes_read: u32 = 0;
         let r = WSARecv(
             self.as_raw_socket() as SOCKET,
             &mut buf,
@@ -645,13 +633,13 @@ impl TcpStreamExt for TcpStream {
     }
 
     fn connect_complete(&self) -> io::Result<()> {
-        const SO_UPDATE_CONNECT_CONTEXT: c_int = 0x7010;
+        const SO_UPDATE_CONNECT_CONTEXT: i32 = 0x7010;
         let result = unsafe {
             setsockopt(
                 self.as_raw_socket() as SOCKET,
-                SOL_SOCKET,
+                SOL_SOCKET as _,
                 SO_UPDATE_CONNECT_CONTEXT,
-                0 as *const _,
+                0 as *mut _,
                 0,
             )
         };
@@ -675,29 +663,20 @@ unsafe fn connect_overlapped(
 ) -> io::Result<Option<usize>> {
     static CONNECTEX: WsaExtension = WsaExtension {
         guid: GUID {
-            Data1: 0x25a207b9,
-            Data2: 0xddf3,
-            Data3: 0x4660,
-            Data4: [0x8e, 0xe9, 0x76, 0xe5, 0x8c, 0x74, 0x06, 0x3e],
+            data1: 0x25a207b9,
+            data2: 0xddf3,
+            data3: 0x4660,
+            data4: [0x8e, 0xe9, 0x76, 0xe5, 0x8c, 0x74, 0x06, 0x3e],
         },
         val: AtomicUsize::new(0),
     };
-    type ConnectEx = unsafe extern "system" fn(
-        SOCKET,
-        *const SOCKADDR,
-        c_int,
-        PVOID,
-        DWORD,
-        LPDWORD,
-        LPOVERLAPPED,
-    ) -> BOOL;
 
     let ptr = CONNECTEX.get(socket)?;
     assert!(ptr != 0);
-    let connect_ex = mem::transmute::<_, ConnectEx>(ptr);
+    let connect_ex = mem::transmute::<_, LPFN_CONNECTEX>(ptr);
 
     let (addr_buf, addr_len) = socket_addr_to_ptrs(addr);
-    let mut bytes_sent: DWORD = 0;
+    let mut bytes_sent: u32 = 0;
     let r = connect_ex(
         socket,
         addr_buf.as_ptr(),
@@ -723,7 +702,7 @@ impl UdpSocketExt for UdpSocket {
     ) -> io::Result<Option<usize>> {
         let mut buf = slice2buf(buf);
         let mut flags = 0;
-        let mut received_bytes: DWORD = 0;
+        let mut received_bytes: u32 = 0;
         let r = WSARecvFrom(
             self.as_raw_socket() as SOCKET,
             &mut buf,
@@ -745,7 +724,7 @@ impl UdpSocketExt for UdpSocket {
     ) -> io::Result<Option<usize>> {
         let mut buf = slice2buf(buf);
         let mut flags = 0;
-        let mut received_bytes: DWORD = 0;
+        let mut received_bytes: u32 = 0;
         let r = WSARecv(
             self.as_raw_socket() as SOCKET,
             &mut buf,
@@ -814,27 +793,17 @@ impl TcpListenerExt for TcpListener {
     ) -> io::Result<bool> {
         static ACCEPTEX: WsaExtension = WsaExtension {
             guid: GUID {
-                Data1: 0xb5367df1,
-                Data2: 0xcbac,
-                Data3: 0x11cf,
-                Data4: [0x95, 0xca, 0x00, 0x80, 0x5f, 0x48, 0xa1, 0x92],
+                data1: 0xb5367df1,
+                data2: 0xcbac,
+                data3: 0x11cf,
+                data4: [0x95, 0xca, 0x00, 0x80, 0x5f, 0x48, 0xa1, 0x92],
             },
             val: AtomicUsize::new(0),
         };
-        type AcceptEx = unsafe extern "system" fn(
-            SOCKET,
-            SOCKET,
-            PVOID,
-            DWORD,
-            DWORD,
-            DWORD,
-            LPDWORD,
-            LPOVERLAPPED,
-        ) -> BOOL;
 
         let ptr = ACCEPTEX.get(self.as_raw_socket() as SOCKET)?;
         assert!(ptr != 0);
-        let accept_ex = mem::transmute::<_, AcceptEx>(ptr);
+        let accept_ex = mem::transmute::<_, LPFN_ACCEPTEX>(ptr);
 
         let mut bytes = 0;
         let (a, b, c, d) = (*addrs).args();
@@ -858,15 +827,15 @@ impl TcpListenerExt for TcpListener {
     }
 
     fn accept_complete(&self, socket: &TcpStream) -> io::Result<()> {
-        const SO_UPDATE_ACCEPT_CONTEXT: c_int = 0x700B;
+        const SO_UPDATE_ACCEPT_CONTEXT: i32 = 0x700B;
         let me = self.as_raw_socket();
         let result = unsafe {
             setsockopt(
                 socket.as_raw_socket() as SOCKET,
-                SOL_SOCKET,
+                SOL_SOCKET as _,
                 SO_UPDATE_ACCEPT_CONTEXT,
-                &me as *const _ as *const _,
-                mem::size_of_val(&me) as c_int,
+                &me as *const _ as *mut _,
+                mem::size_of_val(&me) as i32,
             )
         };
         if result == 0 {
@@ -889,7 +858,7 @@ impl SocketAddrBuf {
     pub fn new() -> SocketAddrBuf {
         SocketAddrBuf {
             buf: unsafe { mem::zeroed() },
-            len: mem::size_of::<SOCKADDR_STORAGE>() as c_int,
+            len: mem::size_of::<SOCKADDR_STORAGE>() as i32,
         }
     }
 
@@ -907,23 +876,13 @@ impl SocketAddrBuf {
 
 static GETACCEPTEXSOCKADDRS: WsaExtension = WsaExtension {
     guid: GUID {
-        Data1: 0xb5367df2,
-        Data2: 0xcbac,
-        Data3: 0x11cf,
-        Data4: [0x95, 0xca, 0x00, 0x80, 0x5f, 0x48, 0xa1, 0x92],
+        data1: 0xb5367df2,
+        data2: 0xcbac,
+        data3: 0x11cf,
+        data4: [0x95, 0xca, 0x00, 0x80, 0x5f, 0x48, 0xa1, 0x92],
     },
     val: AtomicUsize::new(0),
 };
-type GetAcceptExSockaddrs = unsafe extern "system" fn(
-    PVOID,
-    DWORD,
-    DWORD,
-    DWORD,
-    *mut LPSOCKADDR,
-    LPINT,
-    *mut LPSOCKADDR,
-    LPINT,
-);
 
 impl AcceptAddrsBuf {
     /// Creates a new blank buffer ready to be passed to a call to
@@ -948,7 +907,7 @@ impl AcceptAddrsBuf {
         let ptr = GETACCEPTEXSOCKADDRS.get(socket.as_raw_socket() as SOCKET)?;
         assert!(ptr != 0);
         unsafe {
-            let get_sockaddrs = mem::transmute::<_, GetAcceptExSockaddrs>(ptr);
+            let get_sockaddrs = mem::transmute::<_, LPFN_GETACCEPTEXSOCKADDRS>(ptr);
             let (a, b, c, d) = self.args();
             get_sockaddrs(
                 a,
@@ -964,14 +923,14 @@ impl AcceptAddrsBuf {
         }
     }
 
-    fn args(&self) -> (PVOID, DWORD, DWORD, DWORD) {
-        let buf: *const AcceptAddrsBuf = unsafe { mem::zeroed() };
-        let remote_offset = unsafe { &(*buf).remote as *const _ as usize };
+    #[allow(deref_nullptr)]
+    fn args(&self) -> (*mut std::ffi::c_void, u32, u32, u32) {
+        let remote_offset = unsafe { &(*(0 as *const AcceptAddrsBuf)).remote as *const _ as usize };
         (
             self as *const _ as *mut _,
             0,
-            remote_offset as DWORD,
-            (mem::size_of_val(self) - remote_offset) as DWORD,
+            remote_offset as u32,
+            (mem::size_of_val(self) - remote_offset) as u32,
         )
     }
 }
@@ -996,14 +955,18 @@ impl WsaExtension {
         }
         let mut ret = 0 as usize;
         let mut bytes = 0;
+
+        // https://github.com/microsoft/win32metadata/issues/671
+        const SIO_GET_EXTENSION_FUNCTION_POINTER: u32 = 33_5544_3206u32;
+
         let r = unsafe {
             WSAIoctl(
                 socket,
                 SIO_GET_EXTENSION_FUNCTION_POINTER,
                 &self.guid as *const _ as *mut _,
-                mem::size_of_val(&self.guid) as DWORD,
+                mem::size_of_val(&self.guid) as u32,
                 &mut ret as *mut _ as *mut _,
-                mem::size_of_val(&ret) as DWORD,
+                mem::size_of_val(&ret) as u32,
                 &mut bytes,
                 0 as *mut _,
                 None,

--- a/src/overlapped.rs
+++ b/src/overlapped.rs
@@ -3,9 +3,9 @@ use std::io;
 use std::mem;
 use std::ptr;
 
-use winapi::shared::ntdef::{HANDLE, NULL};
-use winapi::um::minwinbase::*;
-use winapi::um::synchapi::*;
+use windows_sys::Win32::Foundation::*;
+use windows_sys::Win32::System::Threading::*;
+use windows_sys::Win32::System::IO::*;
 
 /// A wrapper around `OVERLAPPED` to provide "rustic" accessors and
 /// initializers.
@@ -34,8 +34,8 @@ impl Overlapped {
     /// `Overlapped`.  The event is created with `bManualReset` set to `FALSE`, meaning after a
     /// single thread waits on the event, it will be reset.
     pub fn initialize_with_autoreset_event() -> io::Result<Overlapped> {
-        let event = unsafe { CreateEventW(ptr::null_mut(), 0i32, 0i32, ptr::null()) };
-        if event == NULL {
+        let event = unsafe { CreateEventW(ptr::null_mut(), 0i32, 0i32, ptr::null_mut()) };
+        if event == 0 {
             return Err(io::Error::last_os_error());
         }
         let mut overlapped = Self::zero();
@@ -67,15 +67,16 @@ impl Overlapped {
     /// handles that are on a seeking device that supports the concept of an
     /// offset.
     pub fn set_offset(&mut self, offset: u64) {
-        let s = unsafe { self.0.u.s_mut() };
-        s.Offset = offset as u32;
-        s.OffsetHigh = (offset >> 32) as u32;
+        self.0.Anonymous.Anonymous.Offset = offset as u32;
+        self.0.Anonymous.Anonymous.OffsetHigh = (offset >> 32) as u32;
     }
 
     /// Reads the offset inside this overlapped structure.
     pub fn offset(&self) -> u64 {
-        let s = unsafe { self.0.u.s() };
-        (s.Offset as u64) | ((s.OffsetHigh as u64) << 32)
+        unsafe {
+            (self.0.Anonymous.Anonymous.Offset as u64)
+                | ((self.0.Anonymous.Anonymous.OffsetHigh as u64) << 32)
+        }
     }
 
     /// Sets the `hEvent` field of this structure.

--- a/src/overlapped.rs
+++ b/src/overlapped.rs
@@ -35,7 +35,7 @@ impl Overlapped {
     /// single thread waits on the event, it will be reset.
     pub fn initialize_with_autoreset_event() -> io::Result<Overlapped> {
         let event = unsafe { CreateEventW(ptr::null_mut(), 0i32, 0i32, ptr::null_mut()) };
-        if event == 0 {
+        if event.is_null() {
             return Err(io::Error::last_os_error());
         }
         let mut overlapped = Self::zero();

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -110,18 +110,18 @@ impl<'a> Read for &'a AnonRead {
 }
 
 impl AsRawHandle for AnonRead {
-    fn as_raw_handle(&self) -> *mut std::ffi::c_void {
-        self.0.raw() as _
+    fn as_raw_handle(&self) -> HANDLE {
+        self.0.raw()
     }
 }
 impl FromRawHandle for AnonRead {
-    unsafe fn from_raw_handle(handle: *mut std::ffi::c_void) -> AnonRead {
-        AnonRead(Handle::new(handle as _))
+    unsafe fn from_raw_handle(handle: HANDLE) -> AnonRead {
+        AnonRead(Handle::new(handle))
     }
 }
 impl IntoRawHandle for AnonRead {
-    fn into_raw_handle(self) -> *mut std::ffi::c_void {
-        self.0.into_raw() as _
+    fn into_raw_handle(self) -> HANDLE {
+        self.0.into_raw()
     }
 }
 
@@ -143,18 +143,18 @@ impl<'a> Write for &'a AnonWrite {
 }
 
 impl AsRawHandle for AnonWrite {
-    fn as_raw_handle(&self) -> *mut std::ffi::c_void {
-        self.0.raw() as _
+    fn as_raw_handle(&self) -> HANDLE {
+        self.0.raw()
     }
 }
 impl FromRawHandle for AnonWrite {
-    unsafe fn from_raw_handle(handle: *mut std::ffi::c_void) -> AnonWrite {
-        AnonWrite(Handle::new(handle as _))
+    unsafe fn from_raw_handle(handle: HANDLE) -> AnonWrite {
+        AnonWrite(Handle::new(handle))
     }
 }
 impl IntoRawHandle for AnonWrite {
-    fn into_raw_handle(self) -> *mut std::ffi::c_void {
-        self.0.into_raw() as _
+    fn into_raw_handle(self) -> HANDLE {
+        self.0.into_raw()
     }
 }
 
@@ -434,18 +434,18 @@ impl<'a> Write for &'a NamedPipe {
 }
 
 impl AsRawHandle for NamedPipe {
-    fn as_raw_handle(&self) -> *mut std::ffi::c_void {
-        self.0.raw() as _
+    fn as_raw_handle(&self) -> HANDLE {
+        self.0.raw()
     }
 }
 impl FromRawHandle for NamedPipe {
-    unsafe fn from_raw_handle(handle: *mut std::ffi::c_void) -> NamedPipe {
-        NamedPipe(Handle::new(handle as _))
+    unsafe fn from_raw_handle(handle: HANDLE) -> NamedPipe {
+        NamedPipe(Handle::new(handle))
     }
 }
 impl IntoRawHandle for NamedPipe {
-    fn into_raw_handle(self) -> *mut std::ffi::c_void {
-        self.0.into_raw() as _
+    fn into_raw_handle(self) -> HANDLE {
+        self.0.into_raw()
     }
 }
 


### PR DESCRIPTION
_code authored by @kennykerr_

This is a follow-up PR to PR #47, which we never merged.

Where the previous PR using the `windows` crate showed significant regressions in terms of compilation performance, the new `windows-sys` crate is actually slightly faster to compile than `winapi`. Overall `winapi` and `windows-sys` are very comparable, with a major benefit of `windows-sys` being that it is actively maintained, and supported by Microsoft.

`miow` would be one of the first adopters in the ecosystem of `windows-sys`; but we think that's justified. We need actively maintained bindings to windows APIs in Rust, but without ecosystem adoption we can't get there. So we're making an early move. Despite that though, we're rather confident that these bindings are _correct_, as they're generated entirely from windows metadata, and follow the same pattern as the C++ Windows bindings.

Overall excited for this PR and this direction. Thanks!