### PR TITLE
Update windows-sys to version 0.30.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-target = "x86_64-pc-windows-msvc"
 targets = ["aarch64-pc-windows-msvc", "i686-pc-windows-msvc", "x86_64-pc-windows-msvc"]
 
 [dependencies.windows-sys]
-version = "0.28.0"
+version = "0.30.0"
 features = [
   "Win32_Foundation",
   "Win32_Networking_WinSock",

--- a/src/net.rs
+++ b/src/net.rs
@@ -673,7 +673,7 @@ unsafe fn connect_overlapped(
 
     let ptr = CONNECTEX.get(socket)?;
     assert!(ptr != 0);
-    let connect_ex = mem::transmute::<_, LPFN_CONNECTEX>(ptr);
+    let connect_ex = mem::transmute::<_, LPFN_CONNECTEX>(ptr).unwrap();
 
     let (addr_buf, addr_len) = socket_addr_to_ptrs(addr);
     let mut bytes_sent: u32 = 0;
@@ -803,7 +803,7 @@ impl TcpListenerExt for TcpListener {
 
         let ptr = ACCEPTEX.get(self.as_raw_socket() as SOCKET)?;
         assert!(ptr != 0);
-        let accept_ex = mem::transmute::<_, LPFN_ACCEPTEX>(ptr);
+        let accept_ex = mem::transmute::<_, LPFN_ACCEPTEX>(ptr).unwrap();
 
         let mut bytes = 0;
         let (a, b, c, d) = (*addrs).args();
@@ -907,7 +907,7 @@ impl AcceptAddrsBuf {
         let ptr = GETACCEPTEXSOCKADDRS.get(socket.as_raw_socket() as SOCKET)?;
         assert!(ptr != 0);
         unsafe {
-            let get_sockaddrs = mem::transmute::<_, LPFN_GETACCEPTEXSOCKADDRS>(ptr);
+            let get_sockaddrs = mem::transmute::<_, LPFN_GETACCEPTEXSOCKADDRS>(ptr).unwrap();
             let (a, b, c, d) = self.args();
             get_sockaddrs(
                 a,


### PR DESCRIPTION
Callbacks now consistently use `Option` ([#1344](https://github.com/microsoft/windows-rs/pull/1344))