### PR TITLE
Update to `miow` to use `windows-sys` 0.33

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-target = "x86_64-pc-windows-msvc"
 targets = ["aarch64-pc-windows-msvc", "i686-pc-windows-msvc", "x86_64-pc-windows-msvc"]
 
 [dependencies.windows-sys]
-version = "0.28.0"
+version = "0.33.0"
 features = [
   "Win32_Foundation",
   "Win32_Networking_WinSock",

--- a/src/iocp.rs
+++ b/src/iocp.rs
@@ -43,8 +43,8 @@ impl CompletionPort {
     /// allowed for threads associated with this port. Consult the Windows
     /// documentation for more information about this value.
     pub fn new(threads: u32) -> io::Result<CompletionPort> {
-        let ret = unsafe { CreateIoCompletionPort(INVALID_HANDLE_VALUE, 0 as *mut _, 0, threads) };
-        if ret.is_null() {
+        let ret = unsafe { CreateIoCompletionPort(INVALID_HANDLE_VALUE, 0, 0, threads) };
+        if ret == 0 {
             Err(io::Error::last_os_error())
         } else {
             Ok(CompletionPort {
@@ -63,7 +63,7 @@ impl CompletionPort {
     /// trait can be provided to this function, such as `std::fs::File` and
     /// friends.
     pub fn add_handle<T: AsRawHandle + ?Sized>(&self, token: usize, t: &T) -> io::Result<()> {
-        self._add(token, t.as_raw_handle())
+        self._add(token, t.as_raw_handle() as _)
     }
 
     /// Associates a new `SOCKET` to this I/O completion port.
@@ -82,7 +82,7 @@ impl CompletionPort {
     fn _add(&self, token: usize, handle: HANDLE) -> io::Result<()> {
         assert_eq!(mem::size_of_val(&token), mem::size_of::<usize>());
         let ret = unsafe { CreateIoCompletionPort(handle, self.handle.raw(), token as usize, 0) };
-        if ret.is_null() {
+        if ret == 0 {
             Err(io::Error::last_os_error())
         } else {
             debug_assert_eq!(ret, self.handle.raw());
@@ -183,22 +183,22 @@ impl CompletionPort {
 }
 
 impl AsRawHandle for CompletionPort {
-    fn as_raw_handle(&self) -> HANDLE {
-        self.handle.raw()
+    fn as_raw_handle(&self) -> RawHandle {
+        self.handle.raw() as _
     }
 }
 
 impl FromRawHandle for CompletionPort {
-    unsafe fn from_raw_handle(handle: HANDLE) -> CompletionPort {
+    unsafe fn from_raw_handle(handle: RawHandle) -> CompletionPort {
         CompletionPort {
-            handle: Handle::new(handle),
+            handle: Handle::new(handle as _),
         }
     }
 }
 
 impl IntoRawHandle for CompletionPort {
-    fn into_raw_handle(self) -> HANDLE {
-        self.handle.into_raw()
+    fn into_raw_handle(self) -> RawHandle {
+        self.handle.into_raw() as _
     }
 }
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -672,8 +672,7 @@ unsafe fn connect_overlapped(
     };
 
     let ptr = CONNECTEX.get(socket)?;
-    assert!(ptr != 0);
-    let connect_ex = mem::transmute::<_, LPFN_CONNECTEX>(ptr);
+    let connect_ex = mem::transmute::<_, LPFN_CONNECTEX>(ptr).unwrap();
 
     let (addr_buf, addr_len) = socket_addr_to_ptrs(addr);
     let mut bytes_sent: u32 = 0;
@@ -802,8 +801,7 @@ impl TcpListenerExt for TcpListener {
         };
 
         let ptr = ACCEPTEX.get(self.as_raw_socket() as SOCKET)?;
-        assert!(ptr != 0);
-        let accept_ex = mem::transmute::<_, LPFN_ACCEPTEX>(ptr);
+        let accept_ex = mem::transmute::<_, LPFN_ACCEPTEX>(ptr).unwrap();
 
         let mut bytes = 0;
         let (a, b, c, d) = (*addrs).args();
@@ -905,9 +903,8 @@ impl AcceptAddrsBuf {
             _data: self,
         };
         let ptr = GETACCEPTEXSOCKADDRS.get(socket.as_raw_socket() as SOCKET)?;
-        assert!(ptr != 0);
         unsafe {
-            let get_sockaddrs = mem::transmute::<_, LPFN_GETACCEPTEXSOCKADDRS>(ptr);
+            let get_sockaddrs = mem::transmute::<_, LPFN_GETACCEPTEXSOCKADDRS>(ptr).unwrap();
             let (a, b, c, d) = self.args();
             get_sockaddrs(
                 a,

--- a/src/overlapped.rs
+++ b/src/overlapped.rs
@@ -35,7 +35,7 @@ impl Overlapped {
     /// single thread waits on the event, it will be reset.
     pub fn initialize_with_autoreset_event() -> io::Result<Overlapped> {
         let event = unsafe { CreateEventW(ptr::null_mut(), 0i32, 0i32, ptr::null_mut()) };
-        if event.is_null() {
+        if event == 0 {
             return Err(io::Error::last_os_error());
         }
         let mut overlapped = Self::zero();

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -110,18 +110,18 @@ impl<'a> Read for &'a AnonRead {
 }
 
 impl AsRawHandle for AnonRead {
-    fn as_raw_handle(&self) -> HANDLE {
-        self.0.raw()
+    fn as_raw_handle(&self) -> RawHandle {
+        self.0.raw() as _
     }
 }
 impl FromRawHandle for AnonRead {
-    unsafe fn from_raw_handle(handle: HANDLE) -> AnonRead {
-        AnonRead(Handle::new(handle))
+    unsafe fn from_raw_handle(handle: RawHandle) -> AnonRead {
+        AnonRead(Handle::new(handle as _))
     }
 }
 impl IntoRawHandle for AnonRead {
-    fn into_raw_handle(self) -> HANDLE {
-        self.0.into_raw()
+    fn into_raw_handle(self) -> RawHandle {
+        self.0.into_raw() as _
     }
 }
 
@@ -143,18 +143,18 @@ impl<'a> Write for &'a AnonWrite {
 }
 
 impl AsRawHandle for AnonWrite {
-    fn as_raw_handle(&self) -> HANDLE {
-        self.0.raw()
+    fn as_raw_handle(&self) -> RawHandle {
+        self.0.raw() as _
     }
 }
 impl FromRawHandle for AnonWrite {
-    unsafe fn from_raw_handle(handle: HANDLE) -> AnonWrite {
-        AnonWrite(Handle::new(handle))
+    unsafe fn from_raw_handle(handle: RawHandle) -> AnonWrite {
+        AnonWrite(Handle::new(handle as _))
     }
 }
 impl IntoRawHandle for AnonWrite {
-    fn into_raw_handle(self) -> HANDLE {
-        self.0.into_raw()
+    fn into_raw_handle(self) -> RawHandle {
+        self.0.into_raw() as _
     }
 }
 
@@ -434,18 +434,18 @@ impl<'a> Write for &'a NamedPipe {
 }
 
 impl AsRawHandle for NamedPipe {
-    fn as_raw_handle(&self) -> HANDLE {
-        self.0.raw()
+    fn as_raw_handle(&self) -> RawHandle {
+        self.0.raw() as _
     }
 }
 impl FromRawHandle for NamedPipe {
-    unsafe fn from_raw_handle(handle: HANDLE) -> NamedPipe {
-        NamedPipe(Handle::new(handle))
+    unsafe fn from_raw_handle(handle: RawHandle) -> NamedPipe {
+        NamedPipe(Handle::new(handle as _))
     }
 }
 impl IntoRawHandle for NamedPipe {
-    fn into_raw_handle(self) -> HANDLE {
-        self.0.into_raw()
+    fn into_raw_handle(self) -> RawHandle {
+        self.0.into_raw() as _
     }
 }
 


### PR DESCRIPTION
This brings `miow` in line with the [parking_lot](https://github.com/Amanieu/parking_lot/blob/master/core/Cargo.toml#L26) and [winit](https://github.com/rust-windowing/winit/blob/master/Cargo.toml#L61) crates that have already adopted `windows-sys` version 0.33.