### PR TITLE
Replace wildcard imports with list of needed types

### DIFF
--- a/src/handle.rs
+++ b/src/handle.rs
@@ -1,10 +1,11 @@
-use crate::*;
+use crate::{BOOL, FALSE, TRUE};
 use std::cmp;
 use std::io;
 use std::ptr;
 
-use windows_sys::Win32::Storage::FileSystem::*;
-use windows_sys::Win32::System::IO::*;
+use windows_sys::Win32::Foundation::{CloseHandle, ERROR_IO_INCOMPLETE, ERROR_IO_PENDING, HANDLE};
+use windows_sys::Win32::Storage::FileSystem::{ReadFile, WriteFile};
+use windows_sys::Win32::System::IO::{GetOverlappedResult, OVERLAPPED};
 
 #[derive(Debug)]
 pub struct Handle(HANDLE);

--- a/src/iocp.rs
+++ b/src/iocp.rs
@@ -1,16 +1,20 @@
 //! Bindings to IOCP, I/O Completion Ports
 
-use crate::*;
+use crate::FALSE;
 use std::cmp;
 use std::fmt;
 use std::io;
 use std::mem;
-use std::os::windows::io::*;
+use std::os::windows::io::{AsRawHandle, AsRawSocket, FromRawHandle, IntoRawHandle, RawHandle};
 use std::time::Duration;
 
 use crate::handle::Handle;
 use crate::Overlapped;
-use windows_sys::Win32::System::IO::*;
+use windows_sys::Win32::Foundation::{HANDLE, INVALID_HANDLE_VALUE};
+use windows_sys::Win32::System::IO::{
+    CreateIoCompletionPort, GetQueuedCompletionStatus, GetQueuedCompletionStatusEx,
+    PostQueuedCompletionStatus, OVERLAPPED, OVERLAPPED_ENTRY,
+};
 
 /// A handle to an Windows I/O Completion Port.
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,8 @@ use std::cmp;
 use std::io;
 use std::time::Duration;
 
-use windows_sys::Win32::Foundation::*;
-use windows_sys::Win32::System::WindowsProgramming::*;
+use windows_sys::Win32::Foundation::BOOL;
+use windows_sys::Win32::System::WindowsProgramming::INFINITE;
 
 #[cfg(test)]
 macro_rules! t {

--- a/src/net.rs
+++ b/src/net.rs
@@ -3,18 +3,23 @@
 //! This module contains a number of extension traits for the types in
 //! `std::net` for Windows-specific functionality.
 
-use crate::*;
+use crate::{FALSE, TRUE};
 use std::cmp;
 use std::io;
 use std::mem;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
 use std::net::{SocketAddr, TcpListener, TcpStream, UdpSocket};
-use std::os::windows::prelude::*;
+use std::os::windows::io::AsRawSocket;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use windows_sys::core::*;
-use windows_sys::Win32::Networking::WinSock::*;
-use windows_sys::Win32::System::IO::*;
+use windows_sys::core::GUID;
+use windows_sys::Win32::Networking::WinSock::{
+    setsockopt, WSAGetLastError, WSAGetOverlappedResult, WSAIoctl, WSARecv, WSARecvFrom, WSASend,
+    WSASendTo, AF_INET, AF_INET6, IN6_ADDR, IN6_ADDR_0, IN_ADDR, IN_ADDR_0, LPFN_ACCEPTEX,
+    LPFN_CONNECTEX, LPFN_GETACCEPTEXSOCKADDRS, SOCKADDR, SOCKADDR_IN, SOCKADDR_IN6, SOCKADDR_IN6_0,
+    SOCKADDR_STORAGE, SOCKET, SOCKET_ERROR, SOL_SOCKET, WSABUF, WSA_IO_PENDING,
+};
+use windows_sys::Win32::System::IO::OVERLAPPED;
 
 /// A type to represent a buffer in which a socket address will be stored.
 ///

--- a/src/overlapped.rs
+++ b/src/overlapped.rs
@@ -3,9 +3,9 @@ use std::io;
 use std::mem;
 use std::ptr;
 
-use windows_sys::Win32::Foundation::*;
-use windows_sys::Win32::System::Threading::*;
-use windows_sys::Win32::System::IO::*;
+use windows_sys::Win32::Foundation::HANDLE;
+use windows_sys::Win32::System::Threading::CreateEventW;
+use windows_sys::Win32::System::IO::OVERLAPPED;
 
 /// A wrapper around `OVERLAPPED` to provide "rustic" accessors and
 /// initializers.


### PR DESCRIPTION
When reviewing code I got annoyed by all the wildcard imports. It's really hard to follow where the types come from. IMHO, this is way better.