### PR TITLE
Update html_root_url

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 #![cfg(windows)]
 #![deny(missing_docs)]
 #![allow(bad_style)]
-#![doc(html_root_url = "https://docs.rs/miow/0.3/x86_64-pc-windows-msvc/")]
+#![doc(html_root_url = "https://docs.rs/miow/latest/")]
 
 use std::cmp;
 use std::io;


### PR DESCRIPTION
This updates the `html_root_url` to the latest version. The previous value pointed to an outdated version.

I decided to just use the `latest` URL so you don't need to bother with updating this whenever you do a major version bump. However, I can switch it to `0.5` if you would prefer to keep the version number.

This also removes the `x86_64-pc-windows-msvc` because that is the default target specified in `Cargo.toml` and thus isn't needed (docs.rs will automatically use the default target when not specified).
