### PR TITLE
Bump version to 0.6.0 and add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [v0.6.0] - 2023-08-04
+### Added
+- Add note about this crate being unmaintained.
+
+### Changed
+- Breaking: Upgrade `windows-sys` from 0.42 to 0.48.
+- Upgrade `socket2` from 0.4 to 0.5 (dev dependency only).
+
 ## [v0.5.0] - 2022-11-10
 ### Changed
 - Upgrade `windows-sys` from 0.28 to 0.42.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miow"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
Would be nice to get a version with latest `windows-sys` out on crates.io.