### PR TITLE
remove windows-sys unused feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ features = [
   "Win32_System_IO",
   "Win32_System_Pipes",
   "Win32_System_Threading",
-  "Win32_System_WindowsProgramming",
 ]
 
 [dev-dependencies]


### PR DESCRIPTION
Builds on `x86_64-pc-windows-msvc`, so should be ok.