### PR TITLE
Update windows-sys and socket2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miow"
-version = "0.6.0"
+version = "0.6.1"
 rust-version = "1.77"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
@@ -21,7 +21,7 @@ targets = ["aarch64-pc-windows-msvc", "i686-pc-windows-msvc", "x86_64-pc-windows
 maintenance = { status = "as-is" }
 
 [dependencies.windows-sys]
-version = "0.48.0"
+version = ">=0.60, <=0.61"
 features = [
   "Win32_Foundation",
   "Win32_Networking_WinSock",
@@ -34,4 +34,4 @@ features = [
 
 [dev-dependencies]
 rand = "0.8.0"
-socket2 = "0.5.3"
+socket2 = "0.6.0"

--- a/src/iocp.rs
+++ b/src/iocp.rs
@@ -47,8 +47,10 @@ impl CompletionPort {
     /// allowed for threads associated with this port. Consult the Windows
     /// documentation for more information about this value.
     pub fn new(threads: u32) -> io::Result<CompletionPort> {
-        let ret = unsafe { CreateIoCompletionPort(INVALID_HANDLE_VALUE, 0, 0, threads) };
-        if ret == 0 {
+        let ret = unsafe {
+            CreateIoCompletionPort(INVALID_HANDLE_VALUE, std::ptr::null_mut(), 0, threads)
+        };
+        if ret.is_null() {
             Err(io::Error::last_os_error())
         } else {
             Ok(CompletionPort {
@@ -86,7 +88,7 @@ impl CompletionPort {
     fn _add(&self, token: usize, handle: HANDLE) -> io::Result<()> {
         assert_eq!(mem::size_of_val(&token), mem::size_of::<usize>());
         let ret = unsafe { CreateIoCompletionPort(handle, self.handle.raw(), token, 0) };
-        if ret == 0 {
+        if ret.is_null() {
             Err(io::Error::last_os_error())
         } else {
             debug_assert_eq!(ret, self.handle.raw());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use std::cmp;
 use std::io;
 use std::time::Duration;
 
-use windows_sys::Win32::Foundation::BOOL;
+use windows_sys::core::BOOL;
 use windows_sys::Win32::System::Threading::INFINITE;
 
 #[cfg(test)]

--- a/src/overlapped.rs
+++ b/src/overlapped.rs
@@ -35,7 +35,7 @@ impl Overlapped {
     /// single thread waits on the event, it will be reset.
     pub fn initialize_with_autoreset_event() -> io::Result<Overlapped> {
         let event = unsafe { CreateEventW(ptr::null_mut(), 0i32, 0i32, ptr::null_mut()) };
-        if event == 0 {
+        if event.is_null() {
             return Err(io::Error::last_os_error());
         }
         let mut overlapped = Self::zero();


### PR DESCRIPTION
* Update `windows-sys` to 0.60-0.61.
* Update `socket2` (dev-dep) to 0.6 (which will soon use `windows-sys` 0.60 as well).