### PR TITLE
CI Improvements: min and nightly Rust, min dep version, clippy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,9 +7,6 @@ on:
       - staging
       - trying
 
-env:
-  RUSTFLAGS: -Dwarnings
-
 jobs:
   build_and_test:
     name: Build and test
@@ -17,48 +14,39 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [stable]
+        rust: [1.77, stable, nightly]
 
     steps:
     - uses: actions/checkout@master
 
     - name: Install ${{ matrix.rust }}
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: ${{ matrix.rust }}
-        override: true
+      run: rustup install ${{ matrix.rust }} --component clippy
 
-    - name: check
-      uses: actions-rs/cargo@v1
-      with:
-        command: check
-        args: --all --bins --examples
+    # We don't use warnings-as-errors on nightly since they can be noisy.
+    - name: set warnings env
+      if: ${{ matrix.rust != 'nightly' }}
+      run: echo "RUSTFLAGS=-Dwarnings" >> $GITHUB_ENV
 
-    - name: check unstable
-      uses: actions-rs/cargo@v1
-      with:
-        command:  check
-        args: --all --benches --bins --examples --tests
+    - name: clippy
+      run: cargo +${{ matrix.rust }} clippy --all-targets --all-features -- -Dwarnings
 
     - name: tests
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --all
+      run: cargo +${{ matrix.rust }} test --workspace
+
+    - name: tests (minimal versions)
+      if: ${{ matrix.rust == 'nightly' }}
+      run: rm Cargo.lock && cargo +${{ matrix.rust }} test --workspace -Z unstable-options -Z minimal-versions
 
   check_fmt_and_docs:
     name: Checking fmt and docs
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        components: rustfmt, clippy
-        override: true
 
     - name: fmt
       run: cargo fmt --all -- --check
 
     - name: Docs
-      run: cargo doc
+      run: cargo doc --no-deps --document-private-items
+      env:
+        RUSTDOCFLAGS: -Dwarnings

--- a/src/iocp.rs
+++ b/src/iocp.rs
@@ -297,22 +297,34 @@ mod tests {
     #[test]
     fn get() {
         let c = CompletionPort::new(1).unwrap();
-        c.post(CompletionStatus::new(1, 2, std::ptr::dangling_mut()))
-            .unwrap();
+        c.post(CompletionStatus::new(
+            1,
+            2,
+            std::ptr::NonNull::dangling().as_ptr(),
+        ))
+        .unwrap();
         let s = c.get(None).unwrap();
         assert_eq!(s.bytes_transferred(), 1);
         assert_eq!(s.token(), 2);
-        assert_eq!(s.overlapped(), std::ptr::dangling_mut());
+        assert_eq!(s.overlapped(), std::ptr::NonNull::dangling().as_ptr());
     }
 
     #[test]
     fn get_many() {
         let c = CompletionPort::new(1).unwrap();
 
-        c.post(CompletionStatus::new(1, 2, std::ptr::dangling_mut()))
-            .unwrap();
-        c.post(CompletionStatus::new(4, 5, std::ptr::dangling_mut()))
-            .unwrap();
+        c.post(CompletionStatus::new(
+            1,
+            2,
+            std::ptr::NonNull::dangling().as_ptr(),
+        ))
+        .unwrap();
+        c.post(CompletionStatus::new(
+            4,
+            5,
+            std::ptr::NonNull::dangling().as_ptr(),
+        ))
+        .unwrap();
 
         let mut s = vec![CompletionStatus::zero(); 4];
         {
@@ -320,10 +332,10 @@ mod tests {
             assert_eq!(s.len(), 2);
             assert_eq!(s[0].bytes_transferred(), 1);
             assert_eq!(s[0].token(), 2);
-            assert_eq!(s[0].overlapped(), std::ptr::dangling_mut());
+            assert_eq!(s[0].overlapped(), std::ptr::NonNull::dangling().as_ptr());
             assert_eq!(s[1].bytes_transferred(), 4);
             assert_eq!(s[1].token(), 5);
-            assert_eq!(s[1].overlapped(), std::ptr::dangling_mut());
+            assert_eq!(s[1].overlapped(), std::ptr::NonNull::dangling().as_ptr());
         }
         assert_eq!(s[2].bytes_transferred(), 0);
         assert_eq!(s[2].token(), 0);


### PR DESCRIPTION
* Test with the MSRV (1.77) and nightly Rust compilers.
* Stop using the deprecated `actions-rs` GitHub actions.
* Test against the minimal dependency versions.
* Use `--no-deps` to speed up `cargo doc`.
* Deny warnings in `cargo doc`.
* Don't deny warnings when building with nightly, as they can be noisy.
* Replaced `ptr::dangling_mut` with older API that's available in 1.77.